### PR TITLE
Add an option to disable transforming `Domain` methods 

### DIFF
--- a/.changeset/tough-seas-accept.md
+++ b/.changeset/tough-seas-accept.md
@@ -1,0 +1,5 @@
+---
+"effector-swc-plugin": minor
+---
+
+Add a new `transformLegacyDomainMethods` option to configure transforming `Domain`'s unit creators

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Third, run your build tools and enjoy.
   const $boolean = createBooleanStore() /* Treated as a factory! */
   ```
 
+- `transformLegacyDomainMethods`: `boolean` (default: `true`)
+
+  When disabled, stops transforming [Unit creators in Domains](https://effector.dev/en/api/effector/domain/#unit-creators), like `domain.event()` or `domain.createEffect()`.
+
+  Transforming such calls relies heavily on guessing, and is known to affect/break code unrelated to Effector.
+  An alternative approach to these methods is to use `domain` argument in regular methods:
+
+  ```ts
+  const domain = createDomain();
+
+  // ↓ pass domain as an argument
+  const foo = createEvent({ domain });
+  ```
+
+  > Disabling this option will **stop** adding `sid`s and other debug information into these unit creators. Before turning it off, ensure that your code does not use domain methods.
+
+  Further reading: [You Don't Need Domains](https://withease.pages.dev/magazine/no_domains.html).
+
 ### Known differences with `effector/babel-plugin`
 
 - No support for `importName`
@@ -108,7 +126,7 @@ Third, run your build tools and enjoy.
 
 - No support for `noDefaults`
 
-  This is currently only used by library developers, and will be implemented in the future.
+  This is currently only used by library developers, and may be implemented in the future.
   If you feel you need this feature, please open an issue!
 
 - `reactSsr` replaced by `forceScope`

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,12 @@ pub struct Config {
 
     #[serde(default)]
     pub factories: Vec<String>,
+
+    #[serde(
+        default = "Configurator::enabled",
+        alias = "transformLegacyDomainMethods"
+    )]
+    pub transform_domain_methods: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/visitors/sid/mod.rs
+++ b/src/visitors/sid/mod.rs
@@ -72,8 +72,10 @@ impl UnitIdentifier {
 
                 if self.is_effector(&obj.to_id()) {
                     to_method(&prop.sym)
-                } else {
+                } else if self.config.transform_domain_methods {
                     to_domain_method(&prop.sym)
+                } else {
+                    None
                 }
             }
             _ => None,

--- a/tests/fixtures/domain/no-legacy-methods/config.json
+++ b/tests/fixtures/domain/no-legacy-methods/config.json
@@ -1,0 +1,5 @@
+{
+  "addNames": true,
+  "addLoc": true,
+  "transformLegacyDomainMethods": false
+}

--- a/tests/fixtures/domain/no-legacy-methods/input.js
+++ b/tests/fixtures/domain/no-legacy-methods/input.js
@@ -1,0 +1,22 @@
+import { createDomain } from "effector";
+import { importedDomain } from "./local-file";
+
+const created = createDomain("created");
+// --- event ---
+const event = created.createEvent();
+const eventShort = created.event();
+const eventImported = importedDomain.event("name");
+// --- effect ---
+const effect = created.createEffect(() => 0);
+const effectShort = created.effect({ handler: () => 0 });
+const effectImported = importedDomain.effect(() => 0, { name: "name" });
+// --- store ---
+const store = created.createStore(0);
+const storeShort = created.store(0, { name: "short" });
+const storeImported = importedDomain.store("value");
+// --- domain ---
+const domain = created.createDomain();
+const domainShort = created.domain("name");
+const domainImported = importedDomain.domain();
+// --- usage as argument ---
+createDomain({ name: "second", domain: created });

--- a/tests/fixtures/domain/no-legacy-methods/output.js
+++ b/tests/fixtures/domain/no-legacy-methods/output.js
@@ -1,0 +1,45 @@
+import { createDomain } from "effector";
+import { importedDomain } from "./local-file";
+const created = createDomain("created", {
+    sid: "bm4rhtf8",
+    name: "created",
+    loc: {
+        file: "input.js",
+        line: 4,
+        column: 16
+    }
+});
+// --- event ---
+const event = created.createEvent();
+const eventShort = created.event();
+const eventImported = importedDomain.event("name");
+// --- effect ---
+const effect = created.createEffect(()=>0);
+const effectShort = created.effect({
+    handler: ()=>0
+});
+const effectImported = importedDomain.effect(()=>0, {
+    name: "name"
+});
+// --- store ---
+const store = created.createStore(0);
+const storeShort = created.store(0, {
+    name: "short"
+});
+const storeImported = importedDomain.store("value");
+// --- domain ---
+const domain = created.createDomain();
+const domainShort = created.domain("name");
+const domainImported = importedDomain.domain();
+// --- usage as argument ---
+createDomain({
+    name: "second",
+    domain: created
+}, {
+    sid: "29ysq6c8",
+    loc: {
+        file: "input.js",
+        line: 22,
+        column: 0
+    }
+});


### PR DESCRIPTION
This PR adds a new option `transformLegacyDomainMethods` to configure transforming `Domain`'s unit creators.

`transformLegacyDomainMethods` is enabled by default and is backward-compatible.

Related #12