### PR TITLE
Add optimizaton pass to build script

### DIFF
--- a/.changeset/strong-panthers-walk.md
+++ b/.changeset/strong-panthers-walk.md
@@ -1,0 +1,5 @@
+---
+"effector-swc-plugin": minor
+---
+
+Add optimization pass to build script (`wasm-opt`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ publish = false
 lto = true
 debug = "none"
 strip = "debuginfo"
+opt-level = "s"
+codegen-units = 1
 
 [dependencies]
 ahash = { version = "0.8.11", features = ["std"], default-features = false }

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,7 @@
 [
   { "rust": "0.78.28", "features": "plugin_compat_v1", "node": { "lo": "1.3.63", "hi": "1.3.106" } },
   { "rust": "0.89.8", "features": "plugin_compat_v1", "node": { "lo": "1.3.106", "hi": "1.4.0" } },
-  { "rust": "0.96.9", "features": "plugin_compat_v2", "node": { "lo": "1.4.0", "hi": "1.7.0" } },
+  { "rust": "0.93.4", "features": "plugin_compat_v2", "node": { "lo": "1.4.0", "hi": "1.6.0" } },
+  { "rust": "0.96.9", "features": "plugin_compat_v2", "node": { "lo": "1.6.0", "hi": "1.7.0" } },
   { "rust": "0.99.3", "features": "", "node": { "lo": "1.7.0" } }
 ]


### PR DESCRIPTION
PR adds an additional optimization pass using [`wasm-opt`](https://github.com/WebAssembly/binaryen), plus enables a couple other Rust-specific options.

The plugin is now down to **~900 KB** (from ~2.3 MB) for latest `swc_core` with no performance penalty.